### PR TITLE
Sirupsen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# Requires bump_version from github.com/Shyp/bump_version  
+
 bump:
 	bump_version patch filedb.go 
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+bump:
+	bump_version patch filedb.go 
+
+push: 
+	git push origin --tags
+
+release: test bump push
+	git push --tags
+
+test:
+	go test ./... -cover -bench=. -test.benchtime=3s;

--- a/filedb.go
+++ b/filedb.go
@@ -12,7 +12,7 @@ import (
 )
 
 // VERSION of the lib
-const VERSION = "0.0.1"
+const VERSION = "0.0.2"
 
 // FileDB contains configuration
 type FileDB struct {

--- a/filedb.go
+++ b/filedb.go
@@ -1,14 +1,18 @@
 package fileparsedb
 
 import (
-	log "github.com/Sirupsen/logrus"
-	"github.com/boltdb/bolt"
 	"io/ioutil"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/boltdb/bolt"
+	log "github.com/sirupsen/logrus"
 )
+
+// VERSION of the lib
+const VERSION = "0.0.1"
 
 // FileDB contains configuration
 type FileDB struct {


### PR DESCRIPTION
Vi trenger å fikse sirupsen. Har oppdatert lib + lagt på versjon + makefile for tagging.

go get github.com/Shyp/bump_version
make release